### PR TITLE
Apply change from #494 to Visual C++

### DIFF
--- a/src/Platforms/VisualCpp/UtestPlatform.cpp
+++ b/src/Platforms/VisualCpp/UtestPlatform.cpp
@@ -46,11 +46,14 @@ void PlatformSpecificRestoreJumpBuffer()
     jmp_buf_index--;
 }
 
-void PlatformSpecificRunTestInASeperateProcess(UtestShell* shell, TestPlugin* plugin, TestResult* result)
+static void VisualCppPlatformSpecificRunTestInASeperateProcess(UtestShell* shell, TestPlugin* plugin, TestResult* result)
 {
    printf("-p doesn't work on this platform as it is not implemented. Running inside the process\b");
    shell->runOneTest(plugin, *result);
 }
+
+void (*PlatformSpecificRunTestInASeperateProcess)(UtestShell* shell, TestPlugin* plugin, TestResult* result) =
+        VisualCppPlatformSpecificRunTestInASeperateProcess;
 
 TestOutput::WorkingEnvironment PlatformSpecificGetWorkingEnvironment()
 {


### PR DESCRIPTION
PlatformSpecificRunTestInASeperateProcess was converted to a function pointer, but the visual C++ UtestPlatform.cpp file wasn't updated as well.  Applied the appropriate change to that file as well.
